### PR TITLE
Path resolver broken by new version of TreeView

### DIFF
--- a/lib/tortoise-svn.coffee
+++ b/lib/tortoise-svn.coffee
@@ -22,9 +22,8 @@ tortoiseSvn = (args, cwd) ->
 resolveTreeSelection = ->
   if atom.packages.isPackageLoaded("tree-view")
     treeView = atom.packages.getLoadedPackage("tree-view")
-    treeView = require(treeView.mainModulePath)
-    serialView = treeView.serialize()
-    serialView.selectedPath
+    treeView = treeView.mainModule.treeView
+    treeView.selectedPath
 
 resolveEditorFile = ->
   editor = atom.workspace.getActivePaneItem()


### PR DESCRIPTION
- revised tree view module include method
- removed depreciated serialize method and
replaced with method that matches the new syntax for requesting current path